### PR TITLE
Filter out duplicate ModuleIDs

### DIFF
--- a/src/main/scala/com/github/tkawachi/sbtlock/SbtLock.scala
+++ b/src/main/scala/com/github/tkawachi/sbtlock/SbtLock.scala
@@ -22,6 +22,7 @@ object SbtLock {
       .filter(m => m.organization != "org.scala-lang")
       .map(mod =>
         s"""  "${mod.organization}" % "${mod.name}" % "${mod.revision}"""")
+      .distinct
       .sorted
       .mkString(",\n")
 


### PR DESCRIPTION
I'm getting duplicate ModuleIDs in my generated lock.sbt on 0.13.17.

```
// snip
"com.typesafe.scala-logging" % "scala-logging_2.11" % "3.1.0",
"com.typesafe.scala-logging" % "scala-logging_2.11" % "3.1.0",
"commons-codec" % "commons-codec" % "1.10",
"commons-io" % "commons-io" % "2.4",
"commons-io" % "commons-io" % "2.4",
"commons-logging" % "commons-logging" % "1.1.3",
"commons-logging" % "commons-logging" % "1.1.3",
"io.netty" % "netty-buffer" % "4.0.36.Final",
"io.netty" % "netty-codec" % "4.0.36.Final",
"io.netty" % "netty-codec-http" % "4.0.36.Final",
"io.netty" % "netty-common" % "4.0.36.Final",
"io.netty" % "netty-handler" % "4.0.36.Final",
"io.netty" % "netty-transport" % "4.0.36.Final",
// snip
```

This seems to be happening only on my jenkins workers where I can't attach a debugger, so unfortunately, I'm not sure *why* it's happening. What's worse is that it only happens intermittently.

Regardless, there should never be duplicates in the lock.sbt, so filtering them here as a last resort seems like a sensible thing to do.