### PR TITLE
Added setting key `excludeDependencies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ Add the following line to `~/.sbt/0.13/plugins/sbt-lock.sbt` for sbt 0.13.x,
   `lock.sbt` includes `dependencyOverrides` for all dependent library versions.
   Manage it with version control system.
 * `unlock` to delete `lock.sbt` file.
+
+## Settings
+
+* `excludeDependencies` could be used to exclude some dependencies from locking. This could be required for platform-specific dependencies (e.g. Netty native)
+
+
+    import com.github.tkawachi.sbtlock._
+
+    val settings: Seq[Setting[_]] = Seq(
+      SbtLockKeys.excludeDependencies := Seq(
+        "org.reactivemongo" % "reactivemongo-shaded-native"
+      )
+    )

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add the following line to `~/.sbt/0.13/plugins/sbt-lock.sbt` for sbt 0.13.x,
     import com.github.tkawachi.sbtlock._
 
     val settings: Seq[Setting[_]] = Seq(
-      SbtLockKeys.excludeDependencies := Seq(
+      excludeDependencies in SbtLockKeys.lock := Seq(
         "org.reactivemongo" % "reactivemongo-shaded-native"
       )
     )

--- a/src/main/scala/com/github/tkawachi/sbtlock/SbtLockKeys.scala
+++ b/src/main/scala/com/github/tkawachi/sbtlock/SbtLockKeys.scala
@@ -3,7 +3,6 @@ package com.github.tkawachi.sbtlock
 import sbt.{ ModuleID, _ }
 
 object SbtLockKeys {
-  val excludeDependencies = settingKey[Seq[SbtExclusionRule]]("Dependencies to be ignored by sbt-lock plugin (by organization or organization+name)")
   val sbtLockLockFile = settingKey[String]("A version locking file name. Must ends with `.sbt`.")
   val lock = taskKey[File]("Create a version locking file for sbt-lock")
   val unlock = taskKey[Unit]("Delete a version locking file for sbt-lock")

--- a/src/main/scala/com/github/tkawachi/sbtlock/SbtLockKeys.scala
+++ b/src/main/scala/com/github/tkawachi/sbtlock/SbtLockKeys.scala
@@ -3,6 +3,7 @@ package com.github.tkawachi.sbtlock
 import sbt.{ ModuleID, _ }
 
 object SbtLockKeys {
+  val excludeDependencies = settingKey[Seq[SbtExclusionRule]]("Dependencies to be ignored by sbt-lock plugin (by organization or organization+name)")
   val sbtLockLockFile = settingKey[String]("A version locking file name. Must ends with `.sbt`.")
   val lock = taskKey[File]("Create a version locking file for sbt-lock")
   val unlock = taskKey[Unit]("Delete a version locking file for sbt-lock")

--- a/src/main/scala/com/github/tkawachi/sbtlock/SbtLockPlugin.scala
+++ b/src/main/scala/com/github/tkawachi/sbtlock/SbtLockPlugin.scala
@@ -10,6 +10,7 @@ object SbtLockPlugin extends AutoPlugin {
 
   object autoImport {
     val sbtLockLockFile: SettingKey[String] = SbtLockKeys.sbtLockLockFile
+    val excludeDependencies: SettingKey[Seq[SbtExclusionRule]] = SbtLockKeys.excludeDependencies
     val lock: TaskKey[File] = SbtLockKeys.lock
     val unlock: TaskKey[Unit] = SbtLockKeys.unlock
     val checkLockUpdate: TaskKey[Unit] = SbtLockKeys.checkLockUpdate
@@ -27,6 +28,10 @@ object SbtLockPlugin extends AutoPlugin {
         for {
           art: Artifact <- entry.get(artifact.key)
           mod: ModuleID <- entry.get(moduleID.key)
+          if !excludeDependencies.value.exists { exclude =>
+            exclude.organization == mod.organization && exclude.name == "*" && { logger.debug(s"""[Skipped] "${mod.organization}" % "${mod.name}" % "${mod.revision}" because of exclude by organization"""); true } ||
+              exclude.organization == mod.organization && exclude.name == mod.name && { logger.debug(s"""[Skipped] "${mod.organization}" % "${mod.name}" % "${mod.revision}" because of exclude by organization/name"""); true }
+          }
         } yield {
           logger.debug(
             s"""[Lock] "${mod.organization}" % "${mod.name}" % "${mod.revision}"""")
@@ -83,5 +88,6 @@ object SbtLockPlugin extends AutoPlugin {
 
   override val globalSettings = Seq(
     onLoad in Global ~= { _ compose SbtLock.checkDepUpdates },
-    sbtLockLockFile := DEFAULT_LOCK_FILE_NAME)
+    sbtLockLockFile := DEFAULT_LOCK_FILE_NAME,
+    excludeDependencies := Seq.empty)
 }

--- a/src/main/scala/com/github/tkawachi/sbtlock/SbtLockPlugin.scala
+++ b/src/main/scala/com/github/tkawachi/sbtlock/SbtLockPlugin.scala
@@ -10,7 +10,6 @@ object SbtLockPlugin extends AutoPlugin {
 
   object autoImport {
     val sbtLockLockFile: SettingKey[String] = SbtLockKeys.sbtLockLockFile
-    val excludeDependencies: SettingKey[Seq[SbtExclusionRule]] = SbtLockKeys.excludeDependencies
     val lock: TaskKey[File] = SbtLockKeys.lock
     val unlock: TaskKey[Unit] = SbtLockKeys.unlock
     val checkLockUpdate: TaskKey[Unit] = SbtLockKeys.checkLockUpdate
@@ -28,7 +27,7 @@ object SbtLockPlugin extends AutoPlugin {
         for {
           art: Artifact <- entry.get(artifact.key)
           mod: ModuleID <- entry.get(moduleID.key)
-          if !excludeDependencies.value.exists { exclude =>
+          if !(excludeDependencies in lock).value.exists { exclude =>
             exclude.organization == mod.organization && exclude.name == "*" && { logger.debug(s"""[Skipped] "${mod.organization}" % "${mod.name}" % "${mod.revision}" because of exclude by organization"""); true } ||
               exclude.organization == mod.organization && exclude.name == mod.name && { logger.debug(s"""[Skipped] "${mod.organization}" % "${mod.name}" % "${mod.revision}" because of exclude by organization/name"""); true }
           }
@@ -89,5 +88,5 @@ object SbtLockPlugin extends AutoPlugin {
   override val globalSettings = Seq(
     onLoad in Global ~= { _ compose SbtLock.checkDepUpdates },
     sbtLockLockFile := DEFAULT_LOCK_FILE_NAME,
-    excludeDependencies := Seq.empty)
+    excludeDependencies in lock := Seq.empty)
 }


### PR DESCRIPTION
 Added setting key `excludeDependencies` in order to exclude some dependencies from `lock.sbt`

Use-case: to not lock platform-specific dependencies, e.g. for reactivemongo there are linux-specific and osx-specific libs (where platform is in version part)