### PR TITLE
Add \n to lock.sbt

### DIFF
--- a/src/main/scala/com/github/tkawachi/sbtlock/SbtLock.scala
+++ b/src/main/scala/com/github/tkawachi/sbtlock/SbtLock.scala
@@ -38,7 +38,8 @@ object SbtLock {
          |    )
          |  }
          |}
-         |${SbtLock.DEPS_HASH_PREFIX}${depsHash}""".stripMargin
+         |${SbtLock.DEPS_HASH_PREFIX}${depsHash}
+         |""".stripMargin
 
     IO.write(lockFile, dependencyOverrides)
     log.info(s"$lockFile was created. Commit it to version control system.")


### PR DESCRIPTION
Updating to 0.6.0 triggered the wrath of [pre-commit end-of-file-fixer](https://github.com/pre-commit/pre-commit-hooks/blob/master/pre_commit_hooks/end_of_file_fixer.py) which failed our build.

![screen shot 2018-12-26 at 2 31 54 pm](https://user-images.githubusercontent.com/663139/50455283-0853fe00-091b-11e9-9abb-93f9867d77c3.png)

```
hookid: trailing-whitespace
00:18:45 
00:18:45 Files were modified by this hook. Additional output:
00:18:45 
00:18:45 Fixing lock.sbt
00:18:45 
00:18:45 Fix End of Files.........................................................Failed
00:18:47 hookid: end-of-file-fixer
```

This PR re-adds the \n which is totally my fault for removing in https://github.com/tkawachi/sbt-lock/pull/24/files#diff-f4ae6883e8302684a41b5884459395f0L36.

Totally up to you if you want to make a new tag this. Either way is fine. I can have pre-commit ignore `lock.sbt` files in my builds for now.