### PR TITLE
prefer "version" extra-attribute over revision

### DIFF
--- a/src/main/scala/com/github/tkawachi/sbtlock/SbtLock.scala
+++ b/src/main/scala/com/github/tkawachi/sbtlock/SbtLock.scala
@@ -21,7 +21,7 @@ object SbtLock {
     val moduleLines = allModules
       .filter(m => m.organization != "org.scala-lang")
       .map(mod =>
-        s""""${mod.organization}" % "${mod.name}" % "${mod.revision}"""")
+        s""""${mod.organization}" % "${mod.name}" % "${mod.extraAttributes.getOrElse("version", mod.revision)}"""")
       .distinct
       .sorted
 


### PR DESCRIPTION
The following snippet, for me, yields lockfiles with version ranges:

```
 libraryDependencies ++= List(
      "org.typelevel" %% "cats-core" % "1.5.+",
      "org.typelevel" %% "cats-mtl-core" % "0.4.+",
      "org.typelevel" %% "cats-effect" % "1.1.+",
      "org.scalatest" %% "scalatest" % "3.0.+" % Test
    )
```

...and the output:

```
//...
      "org.typelevel" % "cats-core_2.12" % "1.5.0",
      "org.typelevel" % "cats-effect_2.12" % "1.1.+",
      "org.typelevel" % "cats-kernel_2.12" % "1.5.0",
      "org.typelevel" % "cats-macros_2.12" % "1.5.0",
      "org.typelevel" % "cats-mtl-core_2.12" % "0.4.+",
//...
```

Oddly, some versions are fully resolved and others remain as ranges.

I've altered `SbtLock.scala` to prefer the extra-attribute "version" when available—
this seems to solve the problem.