### PR TITLE
Use `streams.value.log` instead of `sLog`

### DIFF
--- a/src/main/scala/com/github/tkawachi/sbtlock/SbtLockPlugin.scala
+++ b/src/main/scala/com/github/tkawachi/sbtlock/SbtLockPlugin.scala
@@ -92,12 +92,14 @@ object SbtLockPlugin extends AutoPlugin {
         ModificationCheck.hash((libraryDependencies in Compile).value)
       val logger = streams.value.log
       val ignoreOnStaleHash = sbtLockIgnoreOverridesOnStaleHash.value
+      val projectName = name.value
+
       SbtLock.readDepsHash(lockFile) match {
         case Some(hashInFile) =>
           if (hashInFile != currentHash) {
-            logger.debug(s"[${name.value}] hashInFile: $hashInFile, currentHash: $currentHash")
+            logger.debug(s"[$projectName] hashInFile: $hashInFile, currentHash: $currentHash")
             logger.warn(
-              s"[${name.value}] libraryDependencies is updated after ${lockFile.name} was created.")
+              s"[$projectName] libraryDependencies is updated after ${lockFile.name} was created.")
             logger.warn(
               s"Run `;unlock ;reload ;lock` to re-create ${lockFile.name}.")
             logger.warn(
@@ -112,14 +114,14 @@ object SbtLockPlugin extends AutoPlugin {
         case None =>
           if (lockFile.isFile) {
             logger.warn(
-              s"[${name.value}] ${lockFile.name} seems to be created with old version of ${BuildInfo.name}.")
+              s"[$projectName] ${lockFile.name} seems to be created with old version of ${BuildInfo.name}.")
             logger.warn(
               s"Run `;unlock ;reload ;lock` to re-create ${lockFile.name}.")
             logger.warn(
               s"Run just `lock` instead if you want to keep existing library versions.")
           } else if (!lockFile.exists()) {
             logger.info(
-              s"[${name.value}] ${lockFile.name} doesn't exist. Run `lock` to create one.")
+              s"[$projectName] ${lockFile.name} doesn't exist. Run `lock` to create one.")
           }
       }
     })


### PR DESCRIPTION
The change is mostly done to be able to stream the log through the `Language Server Protocol` (so, get it on `sbt-client`). This does not work with `sLog`.

Also added the name of the project being checked in order to have more information of which `lock.sbt` is not up to date.