### PR TITLE
Fix bug where Windows line endings affect the dependency hash

### DIFF
--- a/src/main/scala/com/github/tkawachi/sbtlock/SbtLock.scala
+++ b/src/main/scala/com/github/tkawachi/sbtlock/SbtLock.scala
@@ -53,6 +53,7 @@ object SbtLock {
       lines
         .find(_.startsWith(DEPS_HASH_PREFIX))
         .map(_.drop(DEPS_HASH_PREFIX.length))
+        .map(_.trim)
     } else {
       None
     }

--- a/src/sbt-test/sbt-lock/lineEndings/build.sbt
+++ b/src/sbt-test/sbt-lock/lineEndings/build.sbt
@@ -1,0 +1,18 @@
+// https://github.com/playframework/playframework/blob/2.2.3/framework/project/Dependencies.scala#L101
+libraryDependencies += "com.typesafe.play" %% "play" % "2.2.3"
+
+resolvers += Resolver.typesafeRepo("releases")
+
+scalaVersion := "2.10.4"
+
+TaskKey[Unit]("assertSbtLockHashIsUpToDate") := {
+  assert(
+    sbtLockHashIsUpToDate.value,
+    s"sbtLockHashIsUpToDate.value was not true"
+  )
+}
+
+TaskKey[Unit]("convertToWindowsLineEndings") := {
+  val lockFile = new File(Keys.baseDirectory.value, "lock.sbt")
+  IO.write(lockFile, IO.read(lockFile).replace("\n", "\r\n"))
+}

--- a/src/sbt-test/sbt-lock/lineEndings/project/plugins.sbt
+++ b/src/sbt-test/sbt-lock/lineEndings/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    sys.error("""|The system property 'plugin.version' is not defined.
+                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.github.tkawachi" % "sbt-lock" % pluginVersion)
+}

--- a/src/sbt-test/sbt-lock/lineEndings/test
+++ b/src/sbt-test/sbt-lock/lineEndings/test
@@ -1,0 +1,7 @@
+> lock
+> reload
+> assertSbtLockHashIsUpToDate
+
+> convertToWindowsLineEndings
+> reload
+> assertSbtLockHashIsUpToDate


### PR DESCRIPTION
This fixes a bug where the dependency hash changes if the lock file gets converted to Windows line endings (CRLF) for whatever reason, such as if Git's `autocrlf` setting is enabled on Windows. If this happens, `readDepsHash` would return the hash with a `\r` on the end, making it different from before. Trimming whitespace fixes the issue.